### PR TITLE
comment out deprecation warning

### DIFF
--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -35,7 +35,7 @@ module Temporal
     end
 
     def configuration
-      warn '[DEPRECATION] This method is now deprecated without a substitution'
+      # warn '[DEPRECATION] This method is now deprecated without a substitution'
       config
     end
 
@@ -48,11 +48,11 @@ module Temporal
     end
 
     private
-    
+
     def default_client
       @default_client ||= Client.new(config)
     end
-    
+
     def config
       @config ||= Configuration.new
     end


### PR DESCRIPTION
* don't think this is worth fixing on our end, rather just comment out the warning so we don't spam logs
* right now this is a few thousand logs per hour or so (scales with activities so as we add more load, this will spam more)

https://app.datadoghq.com/logs?query=%22%5BDEPRECATION%5D%20This%20method%20is%20now%20deprecated%20without%20a%20substitution%20%22&index=&from_ts=1655218459702&to_ts=1655823259702&live=true

![image](https://user-images.githubusercontent.com/73492366/174853167-fc58d908-8812-4fc3-832a-595d7d7e553d.png)
