### PR TITLE
Add RequestCancelWorkflowExecution support

### DIFF
--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -190,9 +190,8 @@ module Temporal
       connection.request_cancel_workflow_execution(
         namespace: namespace || execution_options.namespace,
         workflow_id: workflow_id,
+        reason: reason,
         run_id: run_id,
-        signal: signal,
-        input: input
       )
     end
 

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -181,16 +181,14 @@ module Temporal
     # @param workflow [Temporal::Workflow, nil] workflow class or nil
     # @param workflow_id [String]
     # @param run_id [String]
-    # @param reason [String]
     # @param namespace [String, nil] if nil, choose the one declared on the workflow class or the
     #   global default
-    def request_cancel_workflow_execution(workflow, workflow_id, run_id, reason = nil, namespace: nil)
+    def request_cancel_workflow_execution(workflow, workflow_id, run_id, namespace: nil)
       execution_options = ExecutionOptions.new(workflow, {}, config.default_execution_options)
 
       connection.request_cancel_workflow_execution(
         namespace: namespace || execution_options.namespace,
         workflow_id: workflow_id,
-        reason: reason,
         run_id: run_id,
       )
     end

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -176,6 +176,26 @@ module Temporal
       )
     end
 
+    # Request workflow cancelation
+    #
+    # @param workflow [Temporal::Workflow, nil] workflow class or nil
+    # @param workflow_id [String]
+    # @param run_id [String]
+    # @param reason [String]
+    # @param namespace [String, nil] if nil, choose the one declared on the workflow class or the
+    #   global default
+    def request_cancel_workflow_execution(workflow, workflow_id, run_id, reason = nil, namespace: nil)
+      execution_options = ExecutionOptions.new(workflow, {}, config.default_execution_options)
+
+      connection.request_cancel_workflow_execution(
+        namespace: namespace || execution_options.namespace,
+        workflow_id: workflow_id,
+        run_id: run_id,
+        signal: signal,
+        input: input
+      )
+    end
+
     # Long polls for a workflow to be completed and returns workflow's return value.
     #
     # @note This function times out after 30 seconds and throws Temporal::TimeoutError,
@@ -207,7 +227,7 @@ module Temporal
           timeout: timeout || max_timeout,
         )
       rescue GRPC::DeadlineExceeded => e
-        message = if timeout 
+        message = if timeout
           "Timed out after your specified limit of timeout: #{timeout} seconds"
         else
           "Timed out after #{max_timeout} seconds, which is the maximum supported amount."

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -142,7 +142,7 @@ module Temporal
         event_type: :all,
         timeout: nil
       )
-        if wait_for_new_event 
+        if wait_for_new_event
           if timeout.nil?
             # This is an internal error.  Wrappers should enforce this.
             raise "You must specify a timeout when wait_for_new_event = true."
@@ -293,8 +293,17 @@ module Temporal
         raise NotImplementedError
       end
 
-      def request_cancel_workflow_execution
-        raise NotImplementedError
+      def request_cancel_workflow_execution(namespace:, workflow_id:, run_id:, reason: nil)
+        request = Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecution.new(
+          namespace: namespace,
+          workflow_execution: Temporal::Api::Common::V1::WorkflowExecution.new(
+            workflow_id: workflow_id,
+            run_id: run_id
+          ),
+          identity: identity,
+          reason: reason,
+        )
+        client.request_cancel_workflow_execution(request)
       end
 
       def signal_workflow_execution(namespace:, workflow_id:, run_id:, signal:, input: nil)
@@ -534,7 +543,7 @@ module Temporal
 
         sym = Temporal::Workflow::Status::API_STATUS_MAP.invert[value]
         status = Temporal::Api::Enums::V1::WorkflowExecutionStatus.resolve(sym)
-        
+
         Temporal::Api::Filter::V1::StatusFilter.new(status: status)
       end
     end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -293,15 +293,14 @@ module Temporal
         raise NotImplementedError
       end
 
-      def request_cancel_workflow_execution(namespace:, workflow_id:, run_id:, reason: nil)
-        request = Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecution.new(
+      def request_cancel_workflow_execution(namespace:, workflow_id:, run_id:)
+        request = Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionRequest.new(
           namespace: namespace,
           workflow_execution: Temporal::Api::Common::V1::WorkflowExecution.new(
             workflow_id: workflow_id,
             run_id: run_id
           ),
           identity: identity,
-          reason: reason,
         )
         client.request_cancel_workflow_execution(request)
       end

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -343,20 +343,6 @@ describe Temporal::Client do
           namespace: 'default-test-namespace',
           workflow_id: 'workflow_id',
           run_id: 'run_id',
-          reason: nil,
-        )
-    end
-
-    it 'requests with reason' do
-      subject.request_cancel_workflow_execution(TestStartWorkflow, 'workflow_id', 'run_id', 'reason')
-
-      expect(connection)
-        .to have_received(:request_cancel_workflow_execution)
-        .with(
-          namespace: 'default-test-namespace',
-          workflow_id: 'workflow_id',
-          run_id: 'run_id',
-          reason: 'reason',
         )
     end
 
@@ -369,7 +355,6 @@ describe Temporal::Client do
           namespace: 'other-test-namespace',
           workflow_id: 'workflow_id',
           run_id: 'run_id',
-          reason: nil,
         )
     end
   end

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -261,7 +261,7 @@ describe Temporal::Client do
     it 'raises when signal_input is given but signal_name is not' do
       expect do
         subject.start_workflow(
-          TestStartWorkflow, 
+          TestStartWorkflow,
           [42, 54],
           [43, 55],
           options: { signal_input: 'what do you get if you multiply six by nine?', }
@@ -321,13 +321,55 @@ describe Temporal::Client do
 
   describe '#describe_namespace' do
     before { allow(connection).to receive(:describe_namespace).and_return(Temporal::Api::WorkflowService::V1::DescribeNamespaceResponse.new) }
-    
+
     it 'passes the namespace to the connection' do
       result = subject.describe_namespace('new-namespace')
 
       expect(connection)
         .to have_received(:describe_namespace)
         .with(name: 'new-namespace')
+    end
+  end
+
+  describe '#request_cancel_workflow_execution' do
+    before { allow(connection).to receive(:request_cancel_workflow_execution).and_return(nil) }
+
+    it 'makes the request' do
+      subject.request_cancel_workflow_execution(TestStartWorkflow, 'workflow_id', 'run_id')
+
+      expect(connection)
+        .to have_received(:request_cancel_workflow_execution)
+        .with(
+          namespace: 'default-test-namespace',
+          workflow_id: 'workflow_id',
+          run_id: 'run_id',
+        )
+    end
+
+    it 'requests with reason' do
+      subject.request_cancel_workflow_execution(TestStartWorkflow, 'workflow_id', 'run_id', 'reason')
+
+      expect(connection)
+        .to have_received(:request_cancel_workflow_execution)
+        .with(
+          namespace: 'default-test-namespace',
+          workflow_id: 'workflow_id',
+          run_id: 'run_id',
+          input: 'reason',
+        )
+    end
+
+    it 'requests with namespace' do
+      subject.request_cancel_workflow_execution(TestStartWorkflow, 'workflow_id', 'run_id', namespace: 'other-test-namespace')
+
+      expect(connection)
+        .to have_received(:request_cancel_workflow_execution)
+        .with(
+          namespace: 'other-test-namespace',
+          workflow_id: 'workflow_id',
+          run_id: 'run_id',
+          reason: nil,
+        )
     end
   end
 
@@ -341,7 +383,7 @@ describe Temporal::Client do
         .to have_received(:signal_workflow_execution)
         .with(
           namespace: 'default-test-namespace',
-          signal: 'signal', 
+          signal: 'signal',
           workflow_id: 'workflow_id',
           run_id: 'run_id',
           input: nil,
@@ -355,7 +397,7 @@ describe Temporal::Client do
         .to have_received(:signal_workflow_execution)
         .with(
           namespace: 'default-test-namespace',
-          signal: 'signal', 
+          signal: 'signal',
           workflow_id: 'workflow_id',
           run_id: 'run_id',
           input: 'input',
@@ -369,7 +411,7 @@ describe Temporal::Client do
         .to have_received(:signal_workflow_execution)
         .with(
           namespace: 'other-test-namespace',
-          signal: 'signal', 
+          signal: 'signal',
           workflow_id: 'workflow_id',
           run_id: 'run_id',
           input: nil,
@@ -409,7 +451,7 @@ describe Temporal::Client do
       )
     end
 
-    it 'can override the namespace' do 
+    it 'can override the namespace' do
       completed_event = Fabricate(:workflow_completed_event, result: nil)
       response = Fabricate(:workflow_execution_history, events: [completed_event])
 
@@ -494,7 +536,7 @@ describe Temporal::Client do
       end.to raise_error(Temporal::WorkflowCanceled)
     end
 
-    it 'raises TimeoutError when the server times out' do 
+    it 'raises TimeoutError when the server times out' do
       response = Fabricate(:workflow_execution_history, events: [])
       expect(connection)
         .to receive(:get_workflow_execution_history)

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -343,6 +343,7 @@ describe Temporal::Client do
           namespace: 'default-test-namespace',
           workflow_id: 'workflow_id',
           run_id: 'run_id',
+          reason: nil,
         )
     end
 
@@ -355,7 +356,7 @@ describe Temporal::Client do
           namespace: 'default-test-namespace',
           workflow_id: 'workflow_id',
           run_id: 'run_id',
-          input: 'reason',
+          reason: 'reason',
         )
     end
 

--- a/spec/unit/lib/temporal/grpc_client_spec.rb
+++ b/spec/unit/lib/temporal/grpc_client_spec.rb
@@ -8,7 +8,7 @@ describe Temporal::Connection::GRPC do
 
   before do
     allow(subject).to receive(:client).and_return(grpc_stub)
-    
+
     allow(Time).to receive(:now).and_return(now)
   end
 
@@ -35,7 +35,7 @@ describe Temporal::Connection::GRPC do
       end
     end
   end
-  
+
   describe '#signal_with_start_workflow' do
     let(:temporal_response) do
       Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionResponse.new(run_id: 'xxx')
@@ -99,6 +99,29 @@ describe Temporal::Connection::GRPC do
     end
   end
 
+  describe '#request_cancel_workflow_execution' do
+    let(:response) do
+      Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionResponse.new
+    end
+
+    before { allow(grpc_stub).to receive(:request_cancel_workflow_execution).and_return(response) }
+
+    it 'calls GRPC service with supplied arguments' do
+      subject.request_cancel_workflow_execution(
+        namespace: namespace,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+
+      expect(grpc_stub).to have_received(:request_cancel_workflow_execution) do |request|
+        expect(request).to be_an_instance_of(Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionRequest)
+        expect(request.namespace).to eq(namespace)
+        expect(request.workflow_execution.workflow_id).to eq(workflow_id)
+        expect(request.workflow_execution.run_id).to eq(run_id)
+      end
+    end
+  end
+
   describe '#get_workflow_execution_history' do
     let(:response) do
       Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse.new(
@@ -148,7 +171,7 @@ describe Temporal::Connection::GRPC do
         end
       end
 
-      it 'demands a timeout to be specified' do 
+      it 'demands a timeout to be specified' do
         expect do
           subject.get_workflow_execution_history(
             namespace: namespace,
@@ -161,7 +184,7 @@ describe Temporal::Connection::GRPC do
         end
       end
 
-      it 'disallows a timeout larger than the server timeout' do 
+      it 'disallows a timeout larger than the server timeout' do
         expect do
           subject.get_workflow_execution_history(
             namespace: namespace,
@@ -261,7 +284,7 @@ describe Temporal::Connection::GRPC do
         end
       end
     end
-    
+
     describe '#list_closed_workflow_executions' do
       let(:namespace) { 'test-namespace' }
       let(:from) { Time.now - 600 }


### PR DESCRIPTION
as titled.

[asana](https://app.asana.com/0/0/1203467564643371/f) - when a user is already deactivating, we need to cancel their existing workflow and start a new one w/ an updated deactivation date if canceling immediately

## how i tested

* confirmed grpc api with `evans` following [these steps](https://www.notion.so/bankonfound/Temporal-92ebed8a46ce4d6a83535651d9af3fd1#809b171917ad45dc92ec4141b1569ced), and that it worked w/ only namespace, workflow_id, and run_id against dev [see in cloud](https://cloud.temporal.io/namespaces/development.f6692/workflows/subscription_billing%3Asubscription_RaVA5EejLEoC/4a7f4a5e-9326-4a92-8798-05913f46a13e/history/feed)

didn't add `reason` b/c (1) didn't show up in cloud as useful message anyways and (2) [not in the version pinned by this repo](https://github.com/temporalio/api/blob/4c2f6a281fa3fde8b0a24447de3e0d0f47d230b4/temporal/api/workflowservice/v1/request_response.proto#L354)

```
temporal.api.workflowservice.v1.WorkflowService@development.f6692.tmprl.cloud:7233> call RequestCancelWorkflowExecution
namespace (TYPE_STRING) => development.f6692
workflow_execution::workflow_id (TYPE_STRING) => subscription_billing:subscription_RaVA5EejLEoC
workflow_execution::run_id (TYPE_STRING) => 4a7f4a5e-9326-4a92-8798-05913f46a13e
identity (TYPE_STRING) => 
request_id (TYPE_STRING) => 
first_execution_run_id (TYPE_STRING) => 
reason (TYPE_STRING) => 
{}
```

* unit tests
```
$ be rspec spec/unit/lib/temporal/grpc_client_spec.rb
$ be rspec spec/unit/lib/temporal/client_spec.rb
$ be rspec spec
```