### PR TITLE
Implemented TaskQueueActivitiesPerSecond config

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -8,7 +8,8 @@ module Temporal
   class Activity
     class Poller
       DEFAULT_OPTIONS = {
-        thread_pool_size: 20
+        thread_pool_size: 20,
+        max_tasks_per_second: 0, # default value; https://docs.temporal.io/go/how-to-set-workeroptions-in-go#taskqueueactivitiespersecond
       }.freeze
 
       def initialize(namespace, task_queue, activity_lookup, config, middleware = [], options = {})
@@ -74,7 +75,7 @@ module Temporal
       end
 
       def poll_for_task
-        connection.poll_activity_task_queue(namespace: namespace, task_queue: task_queue)
+        connection.poll_activity_task_queue(namespace: namespace, task_queue: task_queue, max_tasks_per_second: options[:max_tasks_per_second])
       rescue ::GRPC::Cancelled
         # We're shutting down and we've already reported that in the logs
         nil

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -204,13 +204,16 @@ module Temporal
         client.respond_workflow_task_failed(request)
       end
 
-      def poll_activity_task_queue(namespace:, task_queue:)
+      def poll_activity_task_queue(namespace:, task_queue:, max_tasks_per_second:)
         request = Temporal::Api::WorkflowService::V1::PollActivityTaskQueueRequest.new(
           identity: identity,
           namespace: namespace,
           task_queue: Temporal::Api::TaskQueue::V1::TaskQueue.new(
             name: task_queue
-          )
+          ),
+          task_queue_metadata: Temporal::Api::TaskQueue::V1::TaskQueueMetadata.new(
+            max_tasks_per_second: max_tasks_per_second,
+          ),
         )
 
         poll_mutex.synchronize do

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -11,7 +11,8 @@ module Temporal
     def initialize(
       config = Temporal.configuration,
       activity_thread_pool_size: Temporal::Activity::Poller::DEFAULT_OPTIONS[:thread_pool_size],
-      workflow_thread_pool_size: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:thread_pool_size]
+      workflow_thread_pool_size: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:thread_pool_size],
+      task_queue_activities_per_second: Temporal::Activity::Poller::DEFAULT_OPTIONS[:max_tasks_per_second]
     )
       @config = config
       @workflows = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
@@ -22,6 +23,7 @@ module Temporal
       @shutting_down = false
       @activity_poller_options = {
         thread_pool_size: activity_thread_pool_size,
+        max_tasks_per_second: task_queue_activities_per_second,
       }
       @workflow_poller_options = {
         thread_pool_size: workflow_thread_pool_size,

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -6,6 +6,7 @@ describe Temporal::Activity::Poller do
   let(:connection) { instance_double('Temporal::Connection::GRPC', cancel_polling_request: nil) }
   let(:namespace) { 'test-namespace' }
   let(:task_queue) { 'test-task-queue' }
+  let(:max_tasks_per_second) { 100_000 }
   let(:lookup) { instance_double('Temporal::ExecutableLookup') }
   let(:thread_pool) do
     instance_double(Temporal::ThreadPool, wait_for_available_threads: nil, shutdown: nil)
@@ -13,8 +14,13 @@ describe Temporal::Activity::Poller do
   let(:config) { Temporal::Configuration.new }
   let(:middleware_chain) { instance_double(Temporal::Middleware::Chain) }
   let(:middleware) { [] }
+  let(:options) {
+    {
+      max_tasks_per_second: max_tasks_per_second,
+    }
+  }
 
-  subject { described_class.new(namespace, task_queue, lookup, config, middleware) }
+  subject { described_class.new(namespace, task_queue, lookup, config, middleware, options) }
 
   before do
     allow(Temporal::Connection).to receive(:generate).and_return(connection)
@@ -35,7 +41,7 @@ describe Temporal::Activity::Poller do
 
       expect(connection)
         .to have_received(:poll_activity_task_queue)
-        .with(namespace: namespace, task_queue: task_queue)
+        .with(namespace: namespace, task_queue: task_queue, max_tasks_per_second: max_tasks_per_second)
         .twice
     end
 

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -168,7 +168,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           config,
           [],
-          thread_pool_size: 20
+          { thread_pool_size: 20, max_tasks_per_second: 0 },
         )
         .and_return(activity_poller_1)
 
@@ -180,7 +180,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           config,
           [],
-          thread_pool_size: 20
+          { thread_pool_size: 20, max_tasks_per_second: 0 },
         )
         .and_return(activity_poller_2)
 
@@ -207,11 +207,36 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           an_instance_of(Temporal::Configuration),
           [],
-          {thread_pool_size: 10}
+          { thread_pool_size: 10, max_tasks_per_second: 0 },
         )
         .and_return(activity_poller)
 
       worker = Temporal::Worker.new(activity_thread_pool_size: 10)
+      allow(worker).to receive(:shutting_down?).and_return(true)
+      worker.register_workflow(TestWorkerWorkflow)
+      worker.register_activity(TestWorkerActivity)
+
+      worker.start
+
+      expect(activity_poller).to have_received(:start)
+
+    end
+
+    it 'can have an activity poller with a different max tasks per second' do
+      activity_poller = instance_double(Temporal::Activity::Poller, start: nil)
+      expect(Temporal::Activity::Poller)
+        .to receive(:new)
+        .with(
+          'default-namespace',
+          'default-task-queue',
+          an_instance_of(Temporal::ExecutableLookup),
+          an_instance_of(Temporal::Configuration),
+          [],
+          { thread_pool_size: 20, max_tasks_per_second: 10_000 },
+        )
+        .and_return(activity_poller)
+
+      worker = Temporal::Worker.new(task_queue_activities_per_second: 10_000)
       allow(worker).to receive(:shutting_down?).and_return(true)
       worker.register_workflow(TestWorkerWorkflow)
       worker.register_activity(TestWorkerActivity)
@@ -264,7 +289,7 @@ describe Temporal::Worker do
             an_instance_of(Temporal::ExecutableLookup),
             config,
             [entry_2],
-            thread_pool_size: 20
+            { thread_pool_size: 20, max_tasks_per_second: 0 },
           )
           .and_return(activity_poller_1)
 


### PR DESCRIPTION
Related: https://docs.temporal.io/go/how-to-set-workeroptions-in-go#taskqueueactivitiespersecond

This PR implements `TaskQueueActivitiesPerSecond` to control the rate of activities across the entire task queue (all workers).

Documentation:
```
Rate limits the number of Activity Executions that can be started per second.

Type: float64
Default: 100000
A value of 0 sets to the default value.

This rate is managed by the Temporal Cluster and limits the Activity Tasks per second for the entire Task Queue. This is in contrast to [WorkerActivityTasksPerSecond](https://docs.temporal.io/go/how-to-set-workeroptions-in-go#workeractivitytaskspersecond) controls activities only per Worker.

Notice that the number is represented in float, so that you can set it to less than 1 if needed. For example, set the number to 0.1 means you want your Activity to be executed once for every 10 seconds. This can be used to protect down stream services from flooding.
```