### PR TITLE
Wrap max_tasks_per_second in DoubleValue

### DIFF
--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -212,7 +212,7 @@ module Temporal
             name: task_queue
           ),
           task_queue_metadata: Temporal::Api::TaskQueue::V1::TaskQueueMetadata.new(
-            max_tasks_per_second: max_tasks_per_second,
+            max_tasks_per_second: Google::Protobuf::DoubleValue(value: max_tasks_per_second),
           ),
         )
 


### PR DESCRIPTION
Fixes
```
Google::Protobuf::TypeError: Invalid type Float to assign to submessage field 'max_tasks_per_second'.\u003e","message":"Unable to poll activity task queue"
```
