### PR TITLE
Ruby 3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-        ruby-version: '2.7.5'
+        ruby-version: '3.1.3'
 
     - run: bundle exec rspec --format documentation

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -34,7 +34,7 @@ module Temporal
           raise ActivityNotRegistered, 'Activity is not registered with this worker'
         end
 
-        result = middleware_chain.invoke(metadata) do
+        result = middleware_chain.invoke(**metadata) do
           activity_class.execute_in_context(context, from_payloads(task.input))
         end
 

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -34,7 +34,7 @@ module Temporal
           raise ActivityNotRegistered, 'Activity is not registered with this worker'
         end
 
-        result = middleware_chain.invoke(**metadata) do
+        result = middleware_chain.invoke(**metadata.to_h) do
           activity_class.execute_in_context(context, from_payloads(task.input))
         end
 

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -103,7 +103,7 @@ describe Temporal::Activity::TaskProcessor do
         it 'invokes the middleware chain' do
           subject.process
 
-          expect(middleware_chain).to have_received(:invoke).with(metadata)
+          expect(middleware_chain).to have_received(:invoke).with(**metadata.to_h)
         end
 
         it 'completes the activity task' do

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -163,7 +163,7 @@ describe Temporal::Activity::TaskProcessor do
         it 'invokes the middleware chain' do
           subject.process
 
-          expect(middleware_chain).to have_received(:invoke).with(metadata)
+          expect(middleware_chain).to have_received(:invoke).with(**metadata.to_h)
         end
 
         it 'fails the activity task' do

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -144,7 +144,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           config,
           [],
-          thread_pool_size: 10
+          { thread_pool_size: 10 },
         )
         .and_return(workflow_poller_1)
 
@@ -156,7 +156,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           config,
           [],
-          thread_pool_size: 10
+          { thread_pool_size: 10 },
         )
         .and_return(workflow_poller_2)
 

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -277,7 +277,7 @@ describe Temporal::Worker do
             an_instance_of(Temporal::ExecutableLookup),
             config,
             [entry_1],
-            thread_pool_size: 10
+            { thread_pool_size: 10 },
           )
           .and_return(workflow_poller_1)
 


### PR DESCRIPTION
b/c [this](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)